### PR TITLE
Add attachment support function

### DIFF
--- a/lib/bamboo/adapters/sparkpost_adapter.ex
+++ b/lib/bamboo/adapters/sparkpost_adapter.ex
@@ -65,6 +65,9 @@ defmodule Bamboo.SparkPostAdapter do
       config
     end
   end
+  
+  @doc false
+  def supports_attachments?, do: true
 
   defp get_key(config) do
     case Map.get(config, :api_key) do


### PR DESCRIPTION
This PR on Bamboo makes it so adapters have to state that they support attachments: https://github.com/thoughtbot/bamboo/pull/284

Thanks again for your work on attachment support in Bamboo