### PR TITLE
Use Bamboo releases in dependency specs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Bamboo.SparkPostAdapter.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:bamboo, github: "andrewtimberlake/bamboo", branch: "feature/attachments"},
+      {:bamboo, "> 0.5.0 and < 2.0.0 or ~> 1.0.0-rc.1"},
       {:ex_doc, "~> 0.9", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},
       {:cowboy, "~> 1.0", only: [:test, :dev]},


### PR DESCRIPTION
Hello @andrewtimberlake ,

Thanks for putting this adapter together! I see that Bamboo dependency points on the attachment support feature which was already merged in 1.0-rc https://github.com/thoughtbot/bamboo/commit/8dff4213e8eefb1d91ed278ca9b12d845ad3115c

and since SparkPost adapter isn't affected by the breaking changes I assume that it might be possible to switch to the Bamboo releases?

We will use it in our app and I promise to get back if something will go wrong with 1.x release ;)   