### PR TITLE
Get rid of Elixir 1.4 warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,8 +14,8 @@ defmodule Bamboo.SparkPostAdapter.Mixfile do
      description: "A Bamboo adapter for the SparkPost email service",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
-     deps: deps,
+     package: package(),
+     deps: deps(),
      docs: fn ->
        [source_ref: "v#{@version}",
         canonical: "http://hexdocs.pm/bamboo_sparkpost",


### PR DESCRIPTION
This will remove Elixir 1.4 compilation warnings:

```
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
deps/bamboo_sparkpost/mix.exs:17

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
deps/bamboo_sparkpost/mix.exs:18
```