### PR TITLE
Add support for request_headers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ config :my_app, MyApp.Mailer,
 
   4. Follow Bamboo [Getting Started Guide](https://github.com/thoughtbot/bamboo#getting-started)
 
-  5. Optionally add `hackney_options` section
+  5. Optionally add `hackney_options` or `request_headers`
 
 ```elixir
 # In your config/config.exs file
@@ -44,7 +44,8 @@ config :my_app, MyApp.Mailer,
   hackney_options: [
     connect_timeout: 8_000,
     recv_timeout: 5_000
-  ]
+  ],
+  request_headers: [{"X-MSYS-SUBACCOUNT", "123"}]
 ```
 
 

--- a/test/bamboo/adapters/sparkpost_adapter_test.exs
+++ b/test/bamboo/adapters/sparkpost_adapter_test.exs
@@ -210,6 +210,16 @@ defmodule Bamboo.SparkPostAdapterTest do
            ]
   end
 
+  test "deliver/2 adds request headers specified in the config" do
+    config = %{adapter: SparkPostAdapter, api_key: "123_abc", request_headers: [{"X-MSYS-SUBACCOUNT", "123"}]}
+    new_email() |> SparkPostAdapter.deliver(config)
+
+    assert_receive {:fake_sparkpost, %{params: params} = conn}
+    assert Plug.Conn.get_req_header(conn, "content-type") == ["application/json"]
+    assert Plug.Conn.get_req_header(conn, "authorization") == [config[:api_key]]
+    assert Plug.Conn.get_req_header(conn, "x-msys-subaccount") == ["123"]
+  end
+
   test "raises if the response is not a success" do
     email = new_email(from: "INVALID_EMAIL")
 


### PR DESCRIPTION
Adds a `request_headers` config option to allow passing of additional HTTP headers to hackney. This is required for [specifying a SparkPost subaccount](https://developers.sparkpost.com/api/subaccounts/#header-the-x-msys-subaccount-header), for example.