### PR TITLE
Use Poison to decode params in error response

### DIFF
--- a/lib/bamboo/adapters/sparkpost_adapter.ex
+++ b/lib/bamboo/adapters/sparkpost_adapter.ex
@@ -34,7 +34,7 @@ defmodule Bamboo.SparkPostAdapter do
 
     case request!(@send_message_path, params, api_key, hackney_options, request_headers) do
       {:ok, status, _headers, response} when status > 299 ->
-        filtered_params = params |> Plug.Conn.Query.decode() |> Map.put("key", "[FILTERED]")
+        filtered_params = params |> Poison.decode!() |> Map.put("key", "[FILTERED]")
         raise_api_error(@service_name, response, filtered_params)
 
       {:error, reason} ->

--- a/test/bamboo/adapters/sparkpost_adapter_test.exs
+++ b/test/bamboo/adapters/sparkpost_adapter_test.exs
@@ -220,19 +220,28 @@ defmodule Bamboo.SparkPostAdapterTest do
     assert Plug.Conn.get_req_header(conn, "x-msys-subaccount") == ["123"]
   end
 
-  test "raises if the response is not a success" do
-    email = new_email(from: "INVALID_EMAIL")
+  describe "error responses" do
+    setup do
+      email = new_email(
+        from: "INVALID_EMAIL",
+        subject: "My Subject",
+        text_body: "TEXT BODY",
+        html_body: "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\">\n<head><title>Email</title>\n<style type=\"text/css\">\nbody {\n width: 100% !important; }\n\n</style>\n</head><body><p>\n<a href=\"https://www.example.org?utm_medium=email&utm_source=campaign\">Contact us</a>\n</p></body></html>"
+      )
 
-    assert_raise Bamboo.ApiError, fn ->
-      email |> SparkPostAdapter.deliver(@config)
+      { :ok, email: email }
     end
-  end
 
-  test "removes api key from error output" do
-    email = new_email(from: "INVALID_EMAIL")
+    test "raises if the response is not a success", %{email: email} do
+      assert_raise Bamboo.ApiError, fn ->
+        email |> SparkPostAdapter.deliver(@config)
+      end
+    end
 
-    assert_raise Bamboo.ApiError, ~r/"key" => "\[FILTERED\]"/, fn ->
-      email |> SparkPostAdapter.deliver(@config)
+    test "removes api key from error output", %{email: email} do
+      assert_raise Bamboo.ApiError, ~r/"key" => "\[FILTERED\]"/, fn ->
+        email |> SparkPostAdapter.deliver(@config)
+      end
     end
   end
 


### PR DESCRIPTION
When an error is returned from the SparkPost API, and the HTML body includes CSS, the `Plug.Conn.Query.decode()` call can fail with a `Plug.Conn.InvalidQueryError`, instead of the expected  `Bamboo.ApiError`. Since the `params` are encoded with `Poison.encode!()` prior to passing them to `request!`, it's logical to use `Poison.decode!()` in parsing them for error logging.

This issue is referenced here https://github.com/andrewtimberlake/bamboo_sparkpost/issues/14