### PR TITLE
Inform about EU-specific base URI config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ config :my_app, MyApp.Mailer,
   api_key: "my-api-key"
 ```
 
+If you are using SparkPost EU, make sure to also add this `:bamboo` configuration:
+
+```elixir
+# In your config/config.exs file
+config :bamboo,
+  sparkpost_base_uri: "https://api.eu.sparkpost.com"
+```
+
   4. Follow Bamboo [Getting Started Guide](https://github.com/thoughtbot/bamboo#getting-started)
 
   5. Optionally add `hackney_options` or `request_headers`


### PR DESCRIPTION
On using this adapter, I noticed I kept getting "Unauthorized" errors from SparkPost.

While inspecting the source code, I saw a `:sparkpost_base_uri` config option which I hadn't found in the README.

To save other people some time, I've added some information about this option to the README.

Side note: I'd expected this setting to be under the `MyApp.Mailer` config namespace, not the generic `:bamboo` config. If this would indeed be better, I'm happy to open a PR for this to change the config setting's location.