### PR TITLE
replace include with import

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The SparkPost adapter provides a helper module for setting tags and other meta d
 ### Examples
 
 ```elixir
-include Bamboo.SparkPostHelper
+import Bamboo.SparkPostHelper
 
 email
 |> tag("my-tag")


### PR DESCRIPTION
I stumbled upon this spelling error.
Bamboo.SparkPostHelper has to be imported instead of included